### PR TITLE
[fix] token revocation in mytoken listing tab

### DIFF
--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -351,6 +351,23 @@ class ApiClient {
 	}
 
 	/**
+	 * Revoke a token by its mom_id
+	 */
+	async revokeTokenByMomID(
+		momId: string,
+		recursive = false
+	): Promise<void> {
+		const endpoint = this.getEndpoint('revocation_endpoint');
+		await this.request(endpoint, {
+			method: 'POST',
+			body: JSON.stringify({
+				mom_id: momId,
+				recursive
+			})
+		});
+	}
+
+	/**
 	 * Revoke the current session (cookie-authenticated).
 	 * Used for logout - revokes the token associated with the current session cookie.
 	 */

--- a/frontend/src/lib/components/ConfirmModal.svelte
+++ b/frontend/src/lib/components/ConfirmModal.svelte
@@ -7,6 +7,9 @@
 	$: confirmText = $ui.confirmModal.confirmText;
 	$: cancelText = $ui.confirmModal.cancelText;
 	$: confirmVariant = $ui.confirmModal.confirmVariant;
+	$: showCheckbox = $ui.confirmModal.showCheckbox;
+	$: checkboxLabel = $ui.confirmModal.checkboxLabel;
+	$: checkboxChecked = $ui.confirmModal.checkboxChecked;
 
 	function handleConfirm() {
 		ui.resolveConfirm(true);
@@ -14,6 +17,11 @@
 
 	function handleCancel() {
 		ui.resolveConfirm(false);
+	}
+
+	function handleCheckboxChange(event: Event) {
+		const target = event.target as HTMLInputElement;
+		ui.setCheckboxState(target.checked);
 	}
 
 	function handleKeydown(event: KeyboardEvent) {
@@ -60,6 +68,20 @@
 				</div>
 				<div class="modal-body">
 					<p class="mb-0">{message}</p>
+					{#if showCheckbox}
+						<div class="form-check mt-2">
+							<input 
+								type="checkbox" 
+								class="form-check-input" 
+								id="recursive-checkbox"
+								checked={checkboxChecked}
+								on:change={handleCheckboxChange}
+							>
+							<label class="form-check-label" for="recursive-checkbox">
+								{checkboxLabel || 'Option'}
+							</label>
+						</div>
+					{/if}
 				</div>
 				<div class="modal-footer">
 					<button type="button" class="btn btn-secondary" on:click={handleCancel}>

--- a/frontend/src/lib/components/tokens/TokenList.svelte
+++ b/frontend/src/lib/components/tokens/TokenList.svelte
@@ -274,24 +274,50 @@
 		return formatDateTime(token.expires_at);
 	}
 
-	async function revokeToken(momId: string, name?: string) {
+	async function revokeToken(momId: string, name?: string, hasChildren?: boolean) {
 		const displayName = name || 'unnamed token';
-		const confirmed = await ui.confirm({
-			title: 'Revoke Token',
-			message: `Are you sure you want to revoke "${displayName}"? This cannot be undone.`,
-			confirmText: 'Revoke',
-			confirmVariant: 'danger'
-		});
 		
-		if (!confirmed) return;
+		if (hasChildren) {
+			const confirmed = await ui.confirm({
+				title: 'Revoke Token',
+				message: `Are you sure you want to revoke "${displayName}"? This cannot be undone.`,
+				confirmText: 'Revoke',
+				confirmVariant: 'danger',
+				showCheckbox: true,
+				checkboxLabel: 'Also revoke all child tokens (recursive)',
+				checkboxChecked: false
+			});
+			
+			if (!confirmed) return;
 
-		try {
-			await api.revokeToken(momId, false);
-			ui.success(`Token "${displayName}" revoked`);
-			await loadTokens(); // Reload the list
-		} catch (err) {
-			if (err instanceof ApiClientError) {
-				ui.showError('Revocation Failed', err.description ?? err.code);
+			try {
+				const recursive = $ui.confirmModal.checkboxChecked ?? false;
+				await api.revokeTokenByMomID(momId, recursive);
+				ui.success(`Token "${displayName}" revoked${recursive ? ' (including children)' : ''}`);
+				await loadTokens();
+			} catch (err) {
+				if (err instanceof ApiClientError) {
+					ui.showError('Revocation Failed', err.description ?? err.code);
+				}
+			}
+		} else {
+			const confirmed = await ui.confirm({
+				title: 'Revoke Token',
+				message: `Are you sure you want to revoke "${displayName}"? This cannot be undone.`,
+				confirmText: 'Revoke',
+				confirmVariant: 'danger'
+			});
+			
+			if (!confirmed) return;
+
+			try {
+				await api.revokeTokenByMomID(momId, false);
+				ui.success(`Token "${displayName}" revoked`);
+				await loadTokens();
+			} catch (err) {
+				if (err instanceof ApiClientError) {
+					ui.showError('Revocation Failed', err.description ?? err.code);
+				}
 			}
 		}
 	}
@@ -477,7 +503,7 @@
 										type="button"
 										class="btn btn-outline-danger"
 										title="Revoke token"
-										onclick={() => revokeToken(token.mom_id, token.name)}
+										onclick={() => revokeToken(token.mom_id, token.name, item.hasChildren)}
 									>
 										<i class="fas fa-trash"></i>
 									</button>

--- a/frontend/src/lib/stores/ui.ts
+++ b/frontend/src/lib/stores/ui.ts
@@ -15,6 +15,9 @@ interface ConfirmModal {
 	cancelText: string;
 	confirmVariant: 'danger' | 'primary' | 'warning';
 	resolve: ((value: boolean) => void) | null;
+	showCheckbox?: boolean;
+	checkboxLabel?: string;
+	checkboxChecked?: boolean;
 }
 
 interface ToastNotification {
@@ -134,6 +137,9 @@ function createUIStore() {
 			confirmText?: string;
 			cancelText?: string;
 			confirmVariant?: 'danger' | 'primary' | 'warning';
+			showCheckbox?: boolean;
+			checkboxLabel?: string;
+			checkboxChecked?: boolean;
 		}): Promise<boolean> {
 			return new Promise((resolve) => {
 				update((state) => ({
@@ -145,6 +151,9 @@ function createUIStore() {
 						confirmText: options.confirmText ?? 'Confirm',
 						cancelText: options.cancelText ?? 'Cancel',
 						confirmVariant: options.confirmVariant ?? 'danger',
+						showCheckbox: options.showCheckbox ?? false,
+						checkboxLabel: options.checkboxLabel ?? '',
+						checkboxChecked: options.checkboxChecked ?? false,
 						resolve
 					}
 				}));
@@ -168,6 +177,19 @@ function createUIStore() {
 					}
 				};
 			});
+		},
+
+		/**
+		 * Set checkbox state in confirm modal
+		 */
+		setCheckboxState(checked: boolean) {
+			update((state) => ({
+				...state,
+				confirmModal: {
+					...state.confirmModal,
+					checkboxChecked: checked
+				}
+			}));
 		},
 
 		/**


### PR DESCRIPTION
- Add new  API method that sends mom_id field instead of token field
- Extend confirm modal to support optional checkbox for recursive toggle
- Update TokenList revoke function to use new API method and show recursive toggle for tokens with children
- Default recursive toggle to unchecked (non-recursive) as safety measure