### PR TITLE
fix(web): prevent revocation of session token by mom_id

### DIFF
--- a/frontend/src/lib/components/tokens/TokenInfo.svelte
+++ b/frontend/src/lib/components/tokens/TokenInfo.svelte
@@ -13,6 +13,7 @@
 	import TagPill from '../TagPill.svelte';
 	import CollapsibleSection from '../CollapsibleSection.svelte';
 	import NotificationClassIcon from '../notifications/NotificationClassIcon.svelte';
+	import { tokenInfo as authStoreTokenInfo } from '$lib/stores/auth';
 
 	// Input token
 	export let initialToken: string = '';
@@ -631,7 +632,7 @@
 									<i class="fas fa-copy me-1"></i>
 									Re-create
 								</button>
-								<button class="btn btn-sm btn-outline-danger" on:click={revokeToken}>
+								<button class="btn btn-sm btn-outline-danger" on:click={revokeToken} disabled={tokenInfo.mom_id === $authStoreTokenInfo?.mom_id}>
 									<i class="fas fa-ban me-1"></i>
 									Revoke
 								</button>

--- a/frontend/src/lib/components/tokens/TokenList.svelte
+++ b/frontend/src/lib/components/tokens/TokenList.svelte
@@ -6,6 +6,7 @@
 	import { tags } from '$lib/stores/tags';
 	import { usersettingsEndpoint, notificationsEndpoint } from '$lib/stores/discovery';
 	import { formatDateTime } from '$lib/utils/format';
+	import { tokenInfo } from '$lib/stores/auth';
 	import LoadingSpinner from '../LoadingSpinner.svelte';
 	import TagPill from '../TagPill.svelte';
 	import TokenTagsCell from './TokenTagsCell.svelte';
@@ -503,6 +504,7 @@
 										type="button"
 										class="btn btn-outline-danger"
 										title="Revoke token"
+										disabled={token.mom_id === $tokenInfo?.mom_id}
 										onclick={() => revokeToken(token.mom_id, token.name, item.hasChildren)}
 									>
 										<i class="fas fa-trash"></i>

--- a/internal/endpoints/revocation/revocationEndpoint.go
+++ b/internal/endpoints/revocation/revocationEndpoint.go
@@ -160,6 +160,16 @@ func revokeByID(
 				}
 				return rollback
 			}
+			if req.MOMID == authToken.ID.Hash() {
+				errRes = &model.Response{
+					Status: fiber.StatusBadRequest,
+					Response: api.Error{
+						Error:            api.ErrorStrInvalidRequest,
+						ErrorDescription: "A token cannot be revoked by its own mom_id. Use the token itself instead.",
+					},
+				}
+				return rollback
+			}
 			if err = helper.RevokeMT(rlog, tx, req.MOMID, req.Recursive); err != nil {
 				errRes = model.ErrorToInternalServerErrorResponse(err)
 				return err


### PR DESCRIPTION
This adds a backend check that returns a 400 Bad Request when the user tries to revoke a token by passing its own mom_id. In the web frontend, the 'Revoke' button for the current session token (matched via mom_id) is now disabled.